### PR TITLE
fix false values not being displayed in query output

### DIFF
--- a/src/components/query/output/grid/Table.vue
+++ b/src/components/query/output/grid/Table.vue
@@ -92,7 +92,7 @@ export default {
 				if (data.ts) {
 					return this.printDate(data.ts / 1000000);
 				}
-				return data.n || data.s || data.f || data.b || data.d || data.bs;
+				return data.n || data.s || data.f || (data.b === false ? 'false' : data.b) || data.d || data.bs;
 			}
 			catch (err) {
 				console.error(err);


### PR DESCRIPTION
Hi there codenotary team,

I have made a PR that fixes an issue with false values not showing correctly in the web console. Even though false values are successfully stored in the database a little flaw in the code makes them not appear in the GUI (src/components/query/output/grid/Table.vue, line 95). The return statement is creating a conflict when extracting the values due to the fact that it will only return data when the operand is true: (see official documentation -> https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Logical_OR). Thus when the value stored is false, the return statement jumps to the next operand, and eventually, returns the last operand in case none is true ("data.bs"). By default, base64 strings are empty and therefore an empty string is returned in the GUI.

To fix this issue and make the false values also visible in the web console, the PR adds a condition in the return statement to make sure that false cases are handled as well as the truth ones.