### PR TITLE
Fix timestamp from nanoseconds to microseconds

### DIFF
--- a/src/components/query/output/grid/Table.vue
+++ b/src/components/query/output/grid/Table.vue
@@ -92,7 +92,7 @@ export default {
 				if (data.ts) {
 					return this.printDate(data.ts / 1000000);
 				}
-				return data.n || data.s || data.f || data.b || data.d || data.bs;
+				return data.n || data.s || data.f || (data.b === false ? 'false' : data.b) || data.d || data.bs;
 			}
 			catch (err) {
 				console.error(err);

--- a/src/components/query/output/grid/Table.vue
+++ b/src/components/query/output/grid/Table.vue
@@ -90,7 +90,7 @@ export default {
 		extractValue (data) {
 			try {
 				if (data.ts) {
-					return this.printDate(data.ts / 1000000);
+					return this.printDate(data.ts / 1000);
 				}
 				return data.n || data.s || data.f || (data.b === false ? 'false' : data.b) || data.d || data.bs;
 			}


### PR DESCRIPTION
Hi there codenotary team,

This PR fixes a collateral issue that is related to this PR -> https://github.com/codenotary/immudb/pull/1045. As mentioned in that PR, a modification in the code is necessary to correctly display the timestamps (src/components/query/output/grid/Table.vue, line 93) and hence the parameters in the printDate function need an adjustment in order to return microseconds instead of nanoseconds.